### PR TITLE
mungall granularity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended
+.PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended test-real-world-integration
 
 # Default target
 all: clean install dev test-coverage format lint mypy deptry build test-medical-integration test-real-world-integration
@@ -62,6 +62,10 @@ release: clean test-coverage build upload
 test-medical-integration:
 	@echo "🔬 Testing medical AI integration..."
 	uv run pytest tests/test_real_world_integration.py::test_diabetes_research_workflow -v -s
+
+test-real-world-integration:
+	@echo "🌍 Testing real-world integration..."
+	uv run pytest tests/test_real_world_integration.py -v
 
 test-cardiac-phenotypes:
 	@echo "❤️ Testing cardiac phenotype discovery..."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended test-real-world-integration
+.PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended test-medical-integration test-real-world-integration
 
 # Default target
-all: clean install dev test-coverage format lint mypy deptry build test-medical-integration test-real-world-integration
+all: clean install dev test-coverage format lint mypy deptry build test-mcp test-mcp-extended test-medical-integration test-real-world-integration
 
 # Install everything for development
 dev:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended
 
 # Default target
-all: clean install dev test-coverage format lint mypy deptry build test-medical-integration
+all: clean install dev test-coverage format lint mypy deptry build test-medical-integration test-real-world-integration
 
 # Install everything for development
 dev:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-coverage clean install dev format lint all server build upload-test upload release deptry mypy test-mcp test-mcp-extended
 
 # Default target
-all: clean install dev test-coverage format lint mypy deptry build test-mcp test-mcp-extended
+all: clean install dev test-coverage format lint mypy deptry build test-medical-integration
 
 # Install everything for development
 dev:
@@ -57,6 +57,35 @@ upload:
 
 # Complete release workflow
 release: clean test-coverage build upload
+
+# Medical AI Integration Testing
+test-medical-integration:
+	@echo "🔬 Testing medical AI integration..."
+	uv run pytest tests/test_real_world_integration.py::test_diabetes_research_workflow -v -s
+
+test-cardiac-phenotypes:
+	@echo "❤️ Testing cardiac phenotype discovery..."
+	uv run pytest tests/test_real_world_integration.py::test_cardiac_phenotype_discovery -v -s
+
+test-cancer-research:
+	@echo "🎯 Testing cancer research workflow..."
+	uv run pytest tests/test_real_world_integration.py::test_cancer_relevancy_ranking -v -s
+
+test-cross-ontology:
+	@echo "🧠 Testing cross-ontology search..."
+	uv run pytest tests/test_real_world_integration.py::test_cross_ontology_brain_research -v -s
+
+test-clinical-workflow:
+	@echo "🏥 Testing clinical decision support..."
+	uv run pytest tests/test_real_world_integration.py::test_clinical_decision_support_workflow -v -s
+
+# Demo medical functionality  
+demo-medical:
+	@echo "🚀 OAK-MCP MEDICAL AI DEMO"
+	@echo "=========================="
+	uv run python -c "import asyncio; from oak_mcp.main import search; asyncio.run(search.fn('diabetes', 'mondo', 3))" | head -10
+	@echo ""
+	@echo "✅ Oak-MCP provides structured medical knowledge for AI agents!"
 
 # MCP Server testing
 test-mcp:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,16 +117,15 @@ async def test_search_specific_medical_terms() -> None:
     # Test ventricular septal defect - a specific heart condition
     results = await search_func("ventricular septal defect", ontology_id="hp", n=3)
 
-    if results:  # OLS might not always have exact matches
-        labels = [result[2] for result in results]
-        # Should find relevant cardiac septal terms
-        assert any(
-            any(
-                keyword in label.lower()
-                for keyword in ["septal", "ventricular", "heart"]
-            )
-            for label in labels
-        )
+    # Assert we get results to ensure test validation
+    assert results, "Should find results for ventricular septal defect search"
+
+    labels = [result[2] for result in results]
+    # Should find relevant cardiac septal terms
+    assert any(
+        any(keyword in label.lower() for keyword in ["septal", "ventricular", "heart"])
+        for label in labels
+    )
 
 
 @pytest.mark.asyncio
@@ -144,11 +143,10 @@ async def test_search_invalid_ontology() -> None:
 @pytest.mark.asyncio
 async def test_get_term_details_useful() -> None:
     """Test get_term_details with a real medical term."""
-    search_func = search.fn
     details_func = get_term_details.fn
 
     # First search for diabetes to get a real term
-    search_results = await search_func("diabetes", ontology_id="mondo", n=1)
+    search_results = await search.fn("diabetes", ontology_id="mondo", n=1)
 
     if search_results:
         term_id = search_results[0][0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,7 +104,7 @@ async def test_search_cross_ontology_brain() -> None:
 
     # Should find terms from anatomy (UBERON) and disease (MONDO) ontologies
     unique_ontologies = set(ontology_ids)
-    assert len(unique_ontologies) >= 1  # At least one ontology
+    assert len(unique_ontologies) >= 2  # At least two ontologies to validate cross-ontology behavior
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,7 +104,9 @@ async def test_search_cross_ontology_brain() -> None:
 
     # Should find terms from anatomy (UBERON) and disease (MONDO) ontologies
     unique_ontologies = set(ontology_ids)
-    assert len(unique_ontologies) >= 2  # At least two ontologies to validate cross-ontology behavior
+    assert (
+        len(unique_ontologies) >= 2
+    )  # At least two ontologies to validate cross-ontology behavior
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from oak_mcp.main import search_ontology_with_oak
+from oak_mcp.main import get_term_details, search
 
 
 def test_reality() -> None:
@@ -8,36 +8,195 @@ def test_reality() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_ontology_with_oak() -> None:
-    """Test the search_ontology_with_oak function with a real ontology search."""
-    # Access the underlying function from the FastMCP tool wrapper
-    search_func = search_ontology_with_oak.fn
+async def test_search_diabetes_mondo() -> None:
+    """Test searching for diabetes in MONDO disease ontology."""
+    search_func = search.fn
 
-    # Test with a known term in MONDO ontology
-    results = await search_func("cancer", "ols:mondo", n=2, verbose=False)
+    # Test with diabetes - should find the main diabetes mellitus term
+    results = await search_func("diabetes", ontology_id="mondo", n=3)
 
     # Verify we get results
     assert isinstance(results, list)
-    assert len(results) <= 2
+    assert len(results) > 0
+    assert len(results) <= 3
 
-    # Verify result format (tuples of ID, label)
-    if results:
-        assert isinstance(results[0], tuple)
-        assert len(results[0]) == 2
-        assert isinstance(results[0][0], str)  # ID
-        assert isinstance(results[0][1], str)  # label
+    # Verify result format (tuples of term_id, ontology_id, label)
+    first_result = results[0]
+    assert isinstance(first_result, tuple)
+    assert len(first_result) == 3
+    assert isinstance(first_result[0], str)  # term_id
+    assert isinstance(first_result[1], str)  # ontology_id
+    assert isinstance(first_result[2], str)  # label
+
+    # Should find the main diabetes mellitus term
+    term_ids = [result[0] for result in results]
+    labels = [result[2] for result in results]
+
+    # Check that we get MONDO diabetes terms
+    assert any("MONDO:" in term_id for term_id in term_ids)
+    assert any("diabetes" in label.lower() for label in labels)
 
 
 @pytest.mark.asyncio
-async def test_search_ontology_invalid_ontology() -> None:
-    """Test error handling with invalid ontology."""
-    search_func = search_ontology_with_oak.fn
+async def test_search_heart_defects_hp() -> None:
+    """Test searching for heart defects in Human Phenotype Ontology."""
+    search_func = search.fn
 
-    # Test with invalid ontology - this should trigger the ValueError/URLError catch
-    # Let's use a malformed URL that will cause urllib.error.URLError
-    results = await search_func(
-        "test", "ols:nonexistent_ontology_12345", n=1, verbose=False
+    # Search for heart defects - should find relevant cardiac abnormalities
+    results = await search_func("heart defect", ontology_id="hp", n=5)
+
+    # Verify we get results
+    assert isinstance(results, list)
+    assert len(results) > 0
+    assert len(results) <= 5
+
+    # Should find HP (Human Phenotype) terms
+    term_ids = [result[0] for result in results]
+    labels = [result[2] for result in results]
+
+    assert any("HP:" in term_id for term_id in term_ids)
+    # Should find terms related to heart/cardiac abnormalities
+    assert any(
+        any(
+            keyword in label.lower()
+            for keyword in ["heart", "cardiac", "septal", "defect"]
+        )
+        for label in labels
     )
+
+
+@pytest.mark.asyncio
+async def test_search_cancer_relevancy() -> None:
+    """Test that cancer search shows relevancy ranking."""
+    search_func = search.fn
+
+    # Test cancer search - should prioritize general cancer term
+    results = await search_func("cancer", ontology_id="mondo", n=3)
+
+    # Verify we get results
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    # First result should be the most relevant (general cancer)
+    first_result = results[0]
+    assert "MONDO:" in first_result[0]  # term_id should be MONDO
+    assert "cancer" in first_result[2].lower()  # label should contain cancer
+
+
+@pytest.mark.asyncio
+async def test_search_cross_ontology_brain() -> None:
+    """Test cross-ontology search for brain terms."""
+    search_func = search.fn
+
+    # Search for brain across all ontologies
+    results = await search_func("brain", ontology_id=None, n=5)
+
+    # Verify we get results from multiple ontologies
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    # Should get results from different ontologies (UBERON, MONDO, etc.)
+    ontology_ids = [result[1] for result in results]
+    labels = [result[2] for result in results]
+
+    # Should have brain-related terms
+    assert any("brain" in label.lower() for label in labels)
+
+    # Should find terms from anatomy (UBERON) and disease (MONDO) ontologies
+    unique_ontologies = set(ontology_ids)
+    assert len(unique_ontologies) >= 1  # At least one ontology
+
+
+@pytest.mark.asyncio
+async def test_search_specific_medical_terms() -> None:
+    """Test searching for specific medical terms shows precision."""
+    search_func = search.fn
+
+    # Test ventricular septal defect - a specific heart condition
+    results = await search_func("ventricular septal defect", ontology_id="hp", n=3)
+
+    if results:  # OLS might not always have exact matches
+        labels = [result[2] for result in results]
+        # Should find relevant cardiac septal terms
+        assert any(
+            any(
+                keyword in label.lower()
+                for keyword in ["septal", "ventricular", "heart"]
+            )
+            for label in labels
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_ontology() -> None:
+    """Test error handling with invalid ontology."""
+    search_func = search.fn
+
+    # Test with invalid ontology - should return empty list
+    results = await search_func("test", ontology_id="nonexistent_ontology_12345", n=1)
 
     # Should return empty list on error
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_get_term_details_useful() -> None:
+    """Test get_term_details with a real medical term."""
+    search_func = search.fn
+    details_func = get_term_details.fn
+
+    # First search for diabetes to get a real term
+    search_results = await search_func("diabetes", ontology_id="mondo", n=1)
+
+    if search_results:
+        term_id = search_results[0][0]
+        details = await details_func(term_id)
+
+        # Verify structure - should be successful for real terms
+        assert isinstance(details, dict)
+
+        if "error" not in details:
+            # Should have core information
+            assert "term_id" in details
+            assert "label" in details
+            assert "definition" in details  # May be None for some terms
+            assert "synonyms" in details  # May be empty list due to OLS limitations
+            assert "ontology_id" in details
+
+            # Verify the term_id matches what we searched for
+            assert details["term_id"] == term_id
+            assert details["label"] is not None
+            assert isinstance(details["synonyms"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_term_details_invalid() -> None:
+    """Test error handling for invalid term ID."""
+    details_func = get_term_details.fn
+
+    # Test with invalid term ID
+    details = await details_func("INVALID:123456")
+
+    # Should return error dict
+    assert isinstance(details, dict)
+    assert "error" in details
+    assert "not found" in details["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ontology_id_extraction() -> None:
+    """Test that ontology IDs are correctly extracted from term IDs."""
+    search_func = search.fn
+
+    # Search MONDO and verify ontology_id extraction
+    results = await search_func("diabetes", ontology_id="mondo", n=1)
+
+    if results:
+        term_id, ontology_id, label = results[0]
+
+        # For MONDO:XXXXX terms, ontology_id should be "mondo"
+        if "MONDO:" in term_id:
+            assert ontology_id == "mondo"
+
+        # Term ID should follow standard format
+        assert ":" in term_id

--- a/tests/test_real_world_integration.py
+++ b/tests/test_real_world_integration.py
@@ -144,23 +144,25 @@ async def test_precision_medical_terminology():
     for term_id, _ontology_id, label in specific_results:
         print(f"  • {term_id}: {label}")
 
-    if specific_results:
-        labels = [result[2] for result in specific_results]
-        # Should find relevant cardiac septal terms
-        cardiac_terms = [
-            label
-            for label in labels
-            if any(
-                keyword in label.lower()
-                for keyword in ["septal", "ventricular", "heart"]
-            )
-        ]
-        print(f"📊 Found {len(cardiac_terms)} cardiac-specific terms")
+    # Assert we get results or mark as expected failure
+    assert specific_results, "Should find results for specific cardiac terminology"
+    
+    labels = [result[2] for result in specific_results]
+    # Should find relevant cardiac septal terms
+    cardiac_terms = [
+        label
+        for label in labels
+        if any(
+            keyword in label.lower()
+            for keyword in ["septal", "ventricular", "heart"]
+        )
+    ]
+    print(f"📊 Found {len(cardiac_terms)} cardiac-specific terms")
 
-        # This demonstrates:
-        # - Precise terminology matching
-        # - Clinical specificity
-        # - Support for detailed medical reasoning
+    # This demonstrates:
+    # - Precise terminology matching
+    # - Clinical specificity
+    # - Support for detailed medical reasoning
 
 
 @pytest.mark.asyncio
@@ -184,13 +186,15 @@ async def test_agent_guidance_different_ontologies():
     print(f"🫀 Anatomy terms: {[r[2] for r in anatomy_results]}")
 
     # Verify ontology-specific results
-    if hp_results and mondo_results:
-        hp_term_ids = [result[0] for result in hp_results]
-        mondo_term_ids = [result[0] for result in mondo_results]
+    assert hp_results, "Should find HP (phenotype) results for heart terms"
+    assert mondo_results, "Should find MONDO (disease) results for heart terms"
+    
+    hp_term_ids = [result[0] for result in hp_results]
+    mondo_term_ids = [result[0] for result in mondo_results]
 
-        # Verify different ontology namespaces
-        assert any("HP:" in term_id for term_id in hp_term_ids)
-        assert any("MONDO:" in term_id for term_id in mondo_term_ids)
+    # Verify different ontology namespaces
+    assert any("HP:" in term_id for term_id in hp_term_ids)
+    assert any("MONDO:" in term_id for term_id in mondo_term_ids)
 
         print("\n✅ Agent Guidance Benefits:")
         print("  • HP: Find patient phenotypes and symptoms")

--- a/tests/test_real_world_integration.py
+++ b/tests/test_real_world_integration.py
@@ -157,6 +157,7 @@ async def test_precision_medical_terminology():
         )
     ]
     print(f"📊 Found {len(cardiac_terms)} cardiac-specific terms")
+    assert cardiac_terms, "Expected to find cardiac-specific terms"
 
     # This demonstrates:
     # - Precise terminology matching
@@ -183,6 +184,7 @@ async def test_agent_guidance_different_ontologies():
     # Anatomy (search for uberon-like terms)
     anatomy_results = await search.fn("heart anatomy", None, 3)
     print(f"🫀 Anatomy terms: {[r[2] for r in anatomy_results]}")
+    assert anatomy_results, "Should find anatomy results for heart terms"
 
     # Verify ontology-specific results
     assert hp_results, "Should find HP (phenotype) results for heart terms"

--- a/tests/test_real_world_integration.py
+++ b/tests/test_real_world_integration.py
@@ -146,15 +146,14 @@ async def test_precision_medical_terminology():
 
     # Assert we get results or mark as expected failure
     assert specific_results, "Should find results for specific cardiac terminology"
-    
+
     labels = [result[2] for result in specific_results]
     # Should find relevant cardiac septal terms
     cardiac_terms = [
         label
         for label in labels
         if any(
-            keyword in label.lower()
-            for keyword in ["septal", "ventricular", "heart"]
+            keyword in label.lower() for keyword in ["septal", "ventricular", "heart"]
         )
     ]
     print(f"📊 Found {len(cardiac_terms)} cardiac-specific terms")
@@ -188,7 +187,7 @@ async def test_agent_guidance_different_ontologies():
     # Verify ontology-specific results
     assert hp_results, "Should find HP (phenotype) results for heart terms"
     assert mondo_results, "Should find MONDO (disease) results for heart terms"
-    
+
     hp_term_ids = [result[0] for result in hp_results]
     mondo_term_ids = [result[0] for result in mondo_results]
 
@@ -196,11 +195,11 @@ async def test_agent_guidance_different_ontologies():
     assert any("HP:" in term_id for term_id in hp_term_ids)
     assert any("MONDO:" in term_id for term_id in mondo_term_ids)
 
-        print("\n✅ Agent Guidance Benefits:")
-        print("  • HP: Find patient phenotypes and symptoms")
-        print("  • MONDO: Find diseases and disorders")
-        print("  • UBERON: Find anatomical structures")
-        print("  • This prevents AI confusion and improves precision!")
+    print("\n✅ Agent Guidance Benefits:")
+    print("  • HP: Find patient phenotypes and symptoms")
+    print("  • MONDO: Find diseases and disorders")
+    print("  • UBERON: Find anatomical structures")
+    print("  • This prevents AI confusion and improves precision!")
 
 
 @pytest.mark.asyncio

--- a/tests/test_real_world_integration.py
+++ b/tests/test_real_world_integration.py
@@ -1,0 +1,234 @@
+"""
+Real-world integration tests demonstrating oak-mcp's medical utility.
+
+These tests show how the MCP functions work for actual medical use cases,
+proving the value for AI agents doing biomedical reasoning.
+"""
+
+import pytest
+
+from oak_mcp.main import get_term_details, search
+
+
+@pytest.mark.asyncio
+async def test_diabetes_research_workflow():
+    """Complete workflow: Diabetes research from search to details."""
+    print("\n🔬 DIABETES RESEARCH WORKFLOW")
+
+    # Step 1: Search for diabetes in diseases
+    diabetes_results = await search.fn("diabetes", "mondo", 5)
+
+    print(f"📊 Found {len(diabetes_results)} diabetes-related terms:")
+    for term_id, _ontology_id, label in diabetes_results:
+        print(f"  • {term_id}: {label}")
+
+    # Verify we found relevant results
+    assert len(diabetes_results) > 0
+    assert any("diabetes mellitus" in label.lower() for _, _, label in diabetes_results)
+
+    # Step 2: Get detailed information about the main diabetes term
+    main_diabetes = diabetes_results[0]  # Most relevant result
+    term_details = await get_term_details.fn(main_diabetes[0])
+
+    print(f"\n📋 Details for {main_diabetes[0]}:")
+    if "error" not in term_details:
+        print(f"  Label: {term_details['label']}")
+        print(f"  Definition: {term_details['definition']}")
+        print(f"  Synonyms: {term_details['synonyms']}")
+    else:
+        print(f"  Note: {term_details['error']}")
+
+    # This workflow demonstrates how an AI agent would:
+    # 1. Search for medical concepts
+    # 2. Get structured ontology terms
+    # 3. Retrieve additional context (definitions, synonyms)
+
+
+@pytest.mark.asyncio
+async def test_cardiac_phenotype_discovery():
+    """Discover cardiac phenotypes for genetic analysis."""
+    print("\n❤️ CARDIAC PHENOTYPE DISCOVERY")
+
+    # Search for heart defects in phenotype ontology
+    heart_phenotypes = await search.fn("heart defect", "hp", 7)
+
+    print(f"🫀 Found {len(heart_phenotypes)} cardiac phenotypes:")
+    for term_id, _ontology_id, label in heart_phenotypes:
+        print(f"  • {term_id}: {label}")
+
+    # Verify we found HP terms related to cardiac issues
+    assert len(heart_phenotypes) > 0
+    term_ids = [result[0] for result in heart_phenotypes]
+    labels = [result[2] for result in heart_phenotypes]
+
+    assert any("HP:" in term_id for term_id in term_ids)
+    assert any(
+        any(
+            keyword in label.lower()
+            for keyword in ["heart", "cardiac", "septal", "defect"]
+        )
+        for label in labels
+    )
+
+    # This shows how AI can find specific phenotypes for:
+    # - Genetic variant interpretation
+    # - Patient phenotyping
+    # - Clinical decision support
+
+
+@pytest.mark.asyncio
+async def test_cancer_relevancy_ranking():
+    """Test OLS relevancy ranking for cancer research."""
+    print("\n🎯 CANCER RELEVANCY RANKING")
+
+    # Search for cancer - should prioritize general over specific
+    cancer_results = await search.fn("cancer", "mondo", 5)
+
+    print("🦠 Cancer search results (by relevancy):")
+    for i, (term_id, _ontology_id, label) in enumerate(cancer_results, 1):
+        print(f"  {i}. {term_id}: {label}")
+
+    # Verify relevancy ranking works
+    assert len(cancer_results) > 0
+    first_result = cancer_results[0]
+
+    # Most relevant should be general cancer term
+    assert "MONDO:" in first_result[0]
+    assert "cancer" in first_result[2].lower()
+
+    # This demonstrates how OLS ranking helps AI agents:
+    # - Find most relevant terms first
+    # - Avoid getting lost in subspecialties
+    # - Start broad, then narrow down
+
+
+@pytest.mark.asyncio
+async def test_cross_ontology_brain_research():
+    """Cross-ontology brain research combining anatomy and disease."""
+    print("\n🧠 CROSS-ONTOLOGY BRAIN RESEARCH")
+
+    # Search across all ontologies for brain terms
+    brain_results = await search.fn("brain", None, 8)
+
+    print("🔍 Brain search across ontologies:")
+    ontology_counts = {}
+    for term_id, ontology_id, label in brain_results:
+        print(f"  • {term_id} ({ontology_id}): {label}")
+        ontology_counts[ontology_id] = ontology_counts.get(ontology_id, 0) + 1
+
+    print(f"\n📈 Ontology distribution: {ontology_counts}")
+
+    # Verify cross-ontology results
+    assert len(brain_results) > 0
+    labels = [result[2] for result in brain_results]
+
+    # Should find brain-related terms
+    assert any("brain" in label.lower() for label in labels)
+
+    # This shows how AI agents can:
+    # - Find anatomical structures (UBERON)
+    # - Find diseases affecting brain (MONDO)
+    # - Find brain-related phenotypes (HP)
+    # - Get comprehensive view across domains
+
+
+@pytest.mark.asyncio
+async def test_precision_medical_terminology():
+    """Test precision with specific medical terminology."""
+    print("\n🎯 PRECISION MEDICAL TERMINOLOGY")
+
+    # Search for specific cardiac condition
+    specific_results = await search.fn("ventricular septal defect", "hp", 5)
+
+    print("🔬 Ventricular septal defect search:")
+    for term_id, _ontology_id, label in specific_results:
+        print(f"  • {term_id}: {label}")
+
+    if specific_results:
+        labels = [result[2] for result in specific_results]
+        # Should find relevant cardiac septal terms
+        cardiac_terms = [
+            label
+            for label in labels
+            if any(
+                keyword in label.lower()
+                for keyword in ["septal", "ventricular", "heart"]
+            )
+        ]
+        print(f"📊 Found {len(cardiac_terms)} cardiac-specific terms")
+
+        # This demonstrates:
+        # - Precise terminology matching
+        # - Clinical specificity
+        # - Support for detailed medical reasoning
+
+
+@pytest.mark.asyncio
+async def test_agent_guidance_different_ontologies():
+    """Show how different ontologies guide AI to appropriate domains."""
+    print("\n🗺️ ONTOLOGY GUIDANCE FOR AI AGENTS")
+
+    # Same term, different ontologies = different perspectives
+    search_term = "heart"
+
+    # Phenotypes (HP) - for patient symptoms/features
+    hp_results = await search.fn(search_term, "hp", 3)
+    print(f"📋 HP (Phenotypes): {[r[2] for r in hp_results]}")
+
+    # Diseases (MONDO) - for diagnoses
+    mondo_results = await search.fn(search_term, "mondo", 3)
+    print(f"🏥 MONDO (Diseases): {[r[2] for r in mondo_results]}")
+
+    # Anatomy (search for uberon-like terms)
+    anatomy_results = await search.fn("heart anatomy", None, 3)
+    print(f"🫀 Anatomy terms: {[r[2] for r in anatomy_results]}")
+
+    # Verify ontology-specific results
+    if hp_results and mondo_results:
+        hp_term_ids = [result[0] for result in hp_results]
+        mondo_term_ids = [result[0] for result in mondo_results]
+
+        # Verify different ontology namespaces
+        assert any("HP:" in term_id for term_id in hp_term_ids)
+        assert any("MONDO:" in term_id for term_id in mondo_term_ids)
+
+        print("\n✅ Agent Guidance Benefits:")
+        print("  • HP: Find patient phenotypes and symptoms")
+        print("  • MONDO: Find diseases and disorders")
+        print("  • UBERON: Find anatomical structures")
+        print("  • This prevents AI confusion and improves precision!")
+
+
+@pytest.mark.asyncio
+async def test_clinical_decision_support_workflow():
+    """Simulate clinical decision support workflow."""
+    print("\n🏥 CLINICAL DECISION SUPPORT WORKFLOW")
+
+    # Scenario: Patient with cardiac symptoms
+    symptoms = ["irregular heartbeat", "chest pain", "shortness of breath"]
+
+    findings = {}
+    for symptom in symptoms:
+        # Search for phenotypes
+        phenotype_results = await search.fn(symptom, "hp", 3)
+
+        # Search for related diseases
+        disease_results = await search.fn(symptom, "mondo", 3)
+
+        findings[symptom] = {
+            "phenotypes": [(r[0], r[2]) for r in phenotype_results[:2]],
+            "diseases": [(r[0], r[2]) for r in disease_results[:2]],
+        }
+
+        print(f"\n🔍 '{symptom}':")
+        print(f"  Phenotypes: {[f[1] for f in findings[symptom]['phenotypes']]}")
+        print(f"  Diseases: {[f[1] for f in findings[symptom]['diseases']]}")
+
+    # Verify we found relevant clinical terms
+    assert len(findings) == len(symptoms)
+
+    print("\n✅ Clinical AI Benefits:")
+    print("  • Structured medical terminology")
+    print("  • Separate symptoms from diagnoses")
+    print("  • Support differential diagnosis")
+    print("  • Enable precise clinical reasoning")


### PR DESCRIPTION
- Uses OLS as sole backend
- Make specifying the target ontology optional
- provides a term details function


One could probably review this PR without worrying too much about the changes to the Makefile and tests